### PR TITLE
Print abort() echo 'Installation aborted' to stdout. Allow \n (ENTER)…

### DIFF
--- a/install
+++ b/install
@@ -34,7 +34,7 @@ comfortable-swipe stop > /dev/null 2>&1 || true
 
 # shorthand to abort the installation
 function abort {
-    echo "Installation aborted"
+    echo "Installation aborted" >&2 
     exit 1
 }
 
@@ -67,10 +67,12 @@ function install_configuration_file {
         # ask user if we overwrite configuration
         echo "Old conf file found in $CONF_TARGET" >&2
         read -r -p "Keep the old conf file? (default: yes) [Y/n] " response >&2
-        if ! [[ "${response,,}" =~ ^(yes|y)$ ]]; then
+        if ! [[ "${response,,}" =~ ^(no|n)$ ]] || [[ "$response" == "" ]]; then
+			continue
+		else
             # MAKE SURE they really want to overwrite
             read -r -p "Conf file will be overwritten! Are you sure? [Y/n] " response >&2
-            if [[ "${response,,}" =~ ^(yes|y)$ ]]; then
+        	if ! [[ "${response,,}" =~ ^(no|n)$ ]] || [[ "$response" == "" ]]; then
                 # They agreed... replace configuration
                 cat "$CONF_SOURCE" > "$CONF_TARGET"
             else


### PR DESCRIPTION
Print abort() echo 'Installation aborted' to stdout. Allow \n (ENTER) to be the printed default: yes.